### PR TITLE
prevent text selection in IE while dragging handle

### DIFF
--- a/jquery.nouislider_0.8.2.js
+++ b/jquery.nouislider_0.8.2.js
@@ -146,6 +146,11 @@
 											var registeredmovement;
 
 												$(useObject).children().addClass('noUi_activeHandle');
+
+												// prevent text selection in IE
+												$('body').bind('selectstart.nouislider', function(e) {
+													return false;
+												});
 											
 												$(document).mousemove(function(f){
 
@@ -215,6 +220,8 @@
 											$(document).mouseup(function(){
 											
 												$(useObject).children().removeClass('noUi_activeHandle');
+
+												$('body').unbind('selectstart.nouislider');
 											
 												$(document).unbind('mousemove');
 												$(document).unbind('mouseup');


### PR DESCRIPTION
Hi Léon,
this is a fix for a bug in Internet Explorer 6-8 (could not test 9 & 10 so far). While dragging a handle and moving the cursor over text, the text got selected. This fix prevents text selection while dragging.
