### PR TITLE
"parseInt" in "locToScale" prevents slider movement when min and max are < 1

### DIFF
--- a/jquery.nouislider.js
+++ b/jquery.nouislider.js
@@ -39,7 +39,7 @@
 					var elementWidth = parseInt(element.css('width'));
 					var knobWidth = parseInt(knob.css('width'));
 					if(!scale){ scale=[0,100]; }
-					return ((elementWidth/(scale[1]-scale[0]))*(parseInt(input)-scale[0]))-(knobWidth/2);
+					return ((elementWidth/(scale[1]-scale[0]))*(parseFloat(input)-scale[0]))-(knobWidth/2);
 				}
 				
 				function scaleToLoc(element, knob, scale){


### PR DESCRIPTION
If the max of a slider is less than one, say 0.7, the 'locToScale' will parse the max value to 0, since it uses "parseInt".

Using parseFloat instead for expected behavior when the max of a slider is < 1.
