### PR TITLE
Ensure the scale is parsed as integers

### DIFF
--- a/jquery.nouislider.js
+++ b/jquery.nouislider.js
@@ -188,7 +188,11 @@
 						/* Append the middle bar */
 						
 						s.connect ? api.connect.appendTo(api.slider) : api.connect = false;
-						
+
+						/* Ensure the scale values are integers */
+
+						s.scale = [parseInt(s.scale[0]), parseInt(s.scale[1])];
+
 						/* Append the handles */
 						
 						// legacy rename


### PR DESCRIPTION
This will fix strange problems with calculating the current value of the slider.

**Problem Example:**

If we had passed the scale of `["25", "200"]`, when the current position of the handle is calculated, and the beginning portion of the scale is added to the calculated value we will have a integer + string. This will cause the beginning portion of the scale to be added as a string instead of a integer.

If the handle was at position `30` and we were calculating the positon it would be `30 + "25"` which will give us `"3025"` instead of `55` like we would expect
