### PR TITLE
Add argument type check to $(".slider").val();

### DIFF
--- a/jquery.nouislider.js
+++ b/jquery.nouislider.js
@@ -292,7 +292,7 @@
 			}
 			,val: function(){
 			
-				if(arguments[0]){
+				if(typeof arguments[0] !== 'undefined'){
 				
 					var val = typeof arguments[0] == 'number' ? [arguments[0]] : arguments[0];
 				


### PR DESCRIPTION
Resolves a bug for $(".slider").val(0) => if(arguments[0]) => false
