### PR TITLE
Add a bower.json file for the Bower package manager

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,16 @@
+{
+	"name": "nouislider",
+	"version": "3.2.1",
+	"main": [
+		"jquery.nouislider.js",
+		"jquery.nouislider.min.js",
+		"nouislider.fox.css",
+		"nouislider.space.css"
+	],
+	"ignore": [
+		"**/.*"
+	],
+	"dependencies": {
+		"jquery": ">= 1.7.0"
+	}
+}


### PR DESCRIPTION
I created this file for [Bower](http://bower.io/) in response to #74. It seems as if there is already a Bower package for nouislider (though I'm not sure if you created it), but Bower would probably want this file to exist anyway. I based the contents of this file off of your `nouislider.jquery.json` file and the result of the `bower init` command.

Notes:
- It seems like Bower installs packages by grabbing the latest tagged release by default, so you will probably need to update nouislider's version (with a git tag) if you want Bower to notice this new file.
- Please double check the list of main files and ignored files in `bower.json`. I assumed that `nouislider.jquery.json` was not needed as a main file.
- I did not register this package with `bower register`, but it seems like somebody else already did. I am a little confused though, as the Bower site says that "a valid manifest JSON" must exist to register the package, and it seems like it was already registered without the `bower.json` file. Maybe Bower was using the `nouislider.jquery.json` file already? If this is the case, I am not completely sure if the `bower.json` file is necessary. I haven't seen anything about this in the Bower documentation, though.

References:
- [Bower website](http://bower.io/)
- [Registering Bower packages](https://github.com/bower/bower#registering-packages)
- [Defining Bower packages](https://github.com/bower/bower#defining-a-package)
- [Bower package index](http://sindresorhus.com/bower-components/)
