### PR TITLE
Fixed relying on global jQuery variable

### DIFF
--- a/jquery.nouislider.js
+++ b/jquery.nouislider.js
@@ -1,6 +1,7 @@
 /* noUiSlider 3.2.1 */
 (function ($) {
 
+    var jQuery = $;
 	$.fn.noUiSlider = function (options, flag) {
 
 		// test for mouse, pointer or touch


### PR DESCRIPTION
While the module function takes and keeps the $ variable value at the moment of initialization, jQuery is referenced several times with a `jQuery` global. If `$.noConflict (true);` is called after the plugin is initialized, `window.jQuery` value will be invalid and the plugin will fail.
