### PR TITLE
Fire an extra event when the user releases the handle/finishes sliding.

### DIFF
--- a/jquery.nouislider.js
+++ b/jquery.nouislider.js
@@ -553,6 +553,7 @@
 			$('body').off(namespace);
 
 			event.data.base.data('target').change();
+			event.data.base.data('target').trigger('slide_end');
 
 		}
 


### PR DESCRIPTION
I added a second event for the following use case:

We have a slider that filters a huge array. We can't use the change event for rendering the array, because it would trigger to often/take to long to render each time, because of that we use the 'slide_end' event to render only after the slider has been released by the user.
