### PR TITLE
Slide callback and change event not firing

### DIFF
--- a/jquery.nouislider.js
+++ b/jquery.nouislider.js
@@ -865,6 +865,13 @@
 						// input from user facing elements.
 						result = setHandle(handle, to, (ignore === true ? false : true));
 
+						// Trigger the 'slide' event, once the value was changed programatically
+                        // pass the target so that it is 'this'.
+                        call(
+                             [ handle.data('nui').options.slide ]
+                            ,handle.closest('.' + clsList[6])
+                        );
+
 						// If the value of the input doesn't match the slider,
 						// reset it.
 						if(!result){


### PR DESCRIPTION
Added extra function call of 'call' within the 'val' function, to
trigger the 'slide' event, once slider's value is changed
programmatically.

Note: I wasn't been able to find a better reference to 'noUi-target', within that function scope. So if you feel like there's a better way, feel free to comment.

P.S. You should totally switch to spaces instead of tabs ;)
