### PR TITLE
Zepto.js compatibility

### DIFF
--- a/jquery.nouislider.js
+++ b/jquery.nouislider.js
@@ -482,7 +482,7 @@
 			// Write the value to the serialization object.
 			handle.data('store').val(
 				format ( percentage.is( nui.range, to ), handle.data('nui').target )
-			);
+			).trigger("change");
 
 			return true;
 


### PR DESCRIPTION
Hi! Since noUiSlider works with touch events i think someone would like to use it with Zepto. But there is a problem - Zepto doesn't support passing custom data with events. There are two ways of solving this problem - either add this feature to Zepto or pass the data by $.proxy.

I've chosen the latter, this is the result. How do you think is this approach suitable? All the data that was passed with events now is going through proxy and noUiSlider works with Zepto.
