### PR TITLE
IE10&11 w/ ZeptoJS 1.1.3 return false instead of null or undefined

### DIFF
--- a/jquery.nouislider.js
+++ b/jquery.nouislider.js
@@ -256,8 +256,7 @@
 			return element.on( events, function( e ){
 
 				// jQuery and Zepto handle unset attributes differently.
-				var disabled = target.attr('disabled');
-					disabled = !( disabled === undefined || disabled === null );
+				var disabled = !!target.attr('disabled');
 
 				// Test if there is anything that should prevent an event
 				// from being handled, such as a disabled state or an active


### PR DESCRIPTION
I've just casted `disabled` to boolean instead of adding `disabled === false` since they all are falsy values.

Tested on IE9-10-11, Win7 and Win8.1.