### PR TITLE
jquery tests arguments by length, not value

### DIFF
--- a/src/js/interface.js
+++ b/src/js/interface.js
@@ -66,7 +66,7 @@
 		}
 
 		// If no value is passed, this is 'get'.
-		if ( arg === undefined ) {
+		if ( !arguments.length ) {
 			var first = $(this[0]);
 			return valMethod(first).call(first);
 		}

--- a/tests/general_val.js
+++ b/tests/general_val.js
@@ -47,4 +47,6 @@
 		Q.find("input").val(function(index, value){
 			equal(value, expectedValues[index]);
 		});
+
+		equal(one.val(undefined), one);
 	});


### PR DESCRIPTION
leongersen/noUiSlider#350 breaks jQuery val by using a strict comparison against undefined instead of arguments.length.

This breaks cases where you might pass an undefined value. It may not be optimal, but it causes issues with, for example, select2, and angularjs.
