### PR TITLE
Don't depend on unordered object

### DIFF
--- a/src/js/range.js
+++ b/src/js/range.js
@@ -184,27 +184,27 @@
 		this.snap = snap;
 		this.direction = direction;
 
-		var that = this, index;
+		var that = this, index, pair;
 
-		// Loop all entries.
+		// Sort all entries by value.
+		var ordered = [ /* [0, 'min'], [1, '50%'], [2, 'max'] */ ];
 		for ( index in entry ) {
 			if ( entry.hasOwnProperty(index) ) {
-				handleEntryPoint(index, entry[index], that);
+				ordered.push([entry[index], index]);
 			}
 		}
-		
-		// entry object is not ordered, and we depend on numbers being sorted further on
-		function numSort(a, b) { return a - b; };
-		this.xPct.sort(numSort);
-		this.xVal.sort(numSort);
+		ordered.sort(function(a, b) { return a[0] - b[0]; });
 
+		// Loop all entries.
+		for ( index = 0; index < ordered.length; index++ ) {
+			pair = ordered[index];
+			handleEntryPoint(pair[1], pair[0], that);
+		}
 		// Store the actual step values.
 		that.xNumSteps = that.xSteps.slice(0);
 
-		for ( index in that.xNumSteps ) {
-			if ( that.xNumSteps.hasOwnProperty(index) ) {
-				handleStepPoint(Number(index), that.xNumSteps[index], that);
-			}
+		for ( index = 0; index < that.xNumSteps.length; index++ ) {
+			handleStepPoint(index, that.xNumSteps[index], that);
 		}
 	}
 


### PR DESCRIPTION
Before, passing `range` as `{min: 1, max: 5, 25%: 2, 50%: 3}` and `{min: 1, 25%: 2, 50%: 3, max: 5}` would mean different results.
Because objects are not guaranteed to return keys in same order, 2 resulting number arrays need to be sorted.
