### PR TITLE
Handle now sizes according to slider height/width, so users can just specify height of parent element and the slider will look good.

### DIFF
--- a/src/jquery.nouislider.css
+++ b/src/jquery.nouislider.css
@@ -66,7 +66,7 @@
 }
 .noUi-horizontal .noUi-handle {
 	width: 34px;
-	height: 28px;
+	height: calc(100% + 12px);
 	left: -17px;
 	top: -6px;
 }
@@ -74,7 +74,7 @@
 	width: 18px;
 }
 .noUi-vertical .noUi-handle {
-	width: 28px;
+	width: calc(100% + 12px);
 	height: 34px;
 	left: -6px;
 	top: -17px;


### PR DESCRIPTION
Slider now takes height from parent element. It did before too, except the handle was hard-coded to 28px. Now handle is calc(100% + 12px) which is supported in everything and IE9+.