### PR TITLE
Fix unbind for old IE

### DIFF
--- a/src/js/scope.js
+++ b/src/js/scope.js
@@ -155,16 +155,18 @@
 			.removeClass(Classes.join(' '))
 			.empty();
 
-		delete this.LinkUpdate;
-		delete this.LinkConfirm;
-		delete this.LinkDefaultFormatter;
-		delete this.LinkDefaultFlag;
-		delete this.reappend;
-		delete this.vGet;
-		delete this.vSet;
-		delete this.getCurrentStep;
-		delete this.getInfo;
-		delete this.destroy;
+		try {
+			delete this.LinkUpdate;
+			delete this.LinkConfirm;
+			delete this.LinkDefaultFormatter;
+			delete this.LinkDefaultFlag;
+			delete this.reappend;
+			delete this.vGet;
+			delete this.vSet;
+			delete this.getCurrentStep;
+			delete this.getInfo;
+			delete this.destroy;
+		} catch (e) {}
 
 		// Return the original options from the closure.
 		return originalOptions;


### PR DESCRIPTION
Wrap the delete operator in a try catch block to avoid throwing errors when unbinding events in old IE browsers (both IE7 & IE8).