### PR TITLE
Reference updated entry point in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nouislider",
   "version": "8.0.1",
-  "main": "distribute/jquery.nouislider",
+  "main": "distribute/nouislider.js",
   "devDependencies": {
     "grunt": "~0.4.1",
     "grunt-contrib-compress": "^0.11.0",


### PR DESCRIPTION
The entry point in package.json needs to be updated to reference 'nouislider.js' instead of 'jquery.nouislider.js'.