### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "main": "distribute/nouislider",
   "license": "WTFPL",
   "devDependencies": {
+    "brfs": "^1.4.0",
     "grunt": "~0.4.1",
     "grunt-contrib-compress": "^0.11.0",
     "grunt-contrib-concat": "^0.5.0",


### PR DESCRIPTION
"Brfs" dependency were added.

I had a problem, when tried to use nouislider in my react project.

A module requires nouslider as a dependency. I build the project with gulp and get the next message:

PS C:\sandbox\react-first> gulp
[21:14:12] Using gulpfile C:\sandbox\react-first\gulpfile.js
[21:14:12] Starting 'concat-css'...
[21:14:12] Finished 'concat-css' after 296 ms
[21:14:12] Starting 'default'...
[21:14:12] Finished 'default' after 25 ms
Error: Cannot find module 'brfs' from 'C:\sandbox\react-first\node_modules\nouislider'

So, this commit just adds brfs dependency. Thank you for considering my request!