### PR TITLE
Fixed: leave slider when mouseup fired on iframe ( issue #498 )

### DIFF
--- a/src/js/scope_events.js
+++ b/src/js/scope_events.js
@@ -41,7 +41,8 @@
 
 	// Handle movement on document for handle and range drag.
 	function move ( event, data ) {
-
+		
+		if(event.which==0) return end(event,data); //fix #498
 		var handles = data.handles || scope_Handles, positions, state = false,
 			proposal = ((event.calcPoint - data.start) * 100) / baseSize(),
 			handleNumber = handles[0] === scope_Handles[0] ? 0 : 1, i;


### PR DESCRIPTION
when keep dragging slider and move cursor on an iframe and then release mouse, mouseup event does not fire and slider keeps dragging.
this code checking mouse is up or not while moving.