### PR TITLE
Check for presence of window, we could be in isomorphic land...

### DIFF
--- a/distribute/nouislider.js
+++ b/distribute/nouislider.js
@@ -132,11 +132,11 @@
 	// Determine the events to bind. IE11 implements pointerEvents without
 	// a prefix, which breaks compatibility with the IE10 implementation.
 	/** @const */
-	actions = window.navigator.pointerEnabled ? {
+	actions = (typeof window !== "undefined" && window.navigator.pointerEnabled) ? {
 		start: 'pointerdown',
 		move: 'pointermove',
 		end: 'pointerup'
-	} : window.navigator.msPointerEnabled ? {
+	} : (typeof window !== "undefined" && window.navigator.msPointerEnabled) ? {
 		start: 'MSPointerDown',
 		move: 'MSPointerMove',
 		end: 'MSPointerUp'

--- a/src/js/constants.js
+++ b/src/js/constants.js
@@ -3,11 +3,11 @@
 	// Determine the events to bind. IE11 implements pointerEvents without
 	// a prefix, which breaks compatibility with the IE10 implementation.
 	/** @const */
-	actions = window.navigator.pointerEnabled ? {
+	actions = (typeof window !== "undefined" && window.navigator.pointerEnabled) ? {
 		start: 'pointerdown',
 		move: 'pointermove',
 		end: 'pointerup'
-	} : window.navigator.msPointerEnabled ? {
+	} : (typeof window !== "undefined" && window.navigator.msPointerEnabled) ? {
 		start: 'MSPointerDown',
 		move: 'MSPointerMove',
 		end: 'MSPointerUp'


### PR DESCRIPTION
Hi...not sure if this is the "right" fix, but we have an isomorphic app that doesn't have `window` defined, so this small fix allowed us to use this incredible widget.

Thoughts?