### PR TITLE
fix: remove brfs dependency, browserify/webpack devs can handle it

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,10 +15,5 @@
   "repository": {
     "type": "git",
     "url": "git://github.com/leongersen/noUiSlider.git"
-  },
-  "browserify": {
-    "transform": [
-      "brfs"
-    ]
   }
 }

--- a/src/js/intro.js
+++ b/src/js/intro.js
@@ -10,13 +10,8 @@
 
     } else if ( typeof exports === 'object' ) {
 
-        var fs = require('fs');
-
         // Node/CommonJS
         module.exports = factory();
-        module.exports.css = function () {
-            return fs.readFileSync(__dirname + '/nouislider.min.css', 'utf8');
-        };
 
     } else {
 


### PR DESCRIPTION
See
https://github.com/leongersen/noUiSlider/commit/60f955d26e1efd1a1ae93b3df91a08881607adfb#commitcomment-13140049

It will lower down the number of issues about this problem. The thing is that the less browserify/webpack dependencies you have the better.

Again, browserify/webpack users can easily require a package css file on their own.