### PR TITLE
Removed jQuery reference in website's title

### DIFF
--- a/documentation/index.php
+++ b/documentation/index.php
@@ -1,5 +1,5 @@
 <?php
-	$title = "noUiSlider - jQuery Range Slider";
+	$title = "noUiSlider - JavaScript Range Slider";
 	$description = "noUiSlider is a free and lightweight JavaScript range slider with full touch support (iOS, Android, Windows 8). Great for responsive designs, and no dependencies!";
 ?>
 


### PR DESCRIPTION
Having jQuery inside the title can be misleading for people when searching for pure javascript range sliders on Google.