### PR TITLE
fixing baseSize()

### DIFF
--- a/src/js/scope_helpers.js
+++ b/src/js/scope_helpers.js
@@ -1,7 +1,8 @@
 
 	// Shorthand for base dimensions.
 	function baseSize ( ) {
-		return scope_Base['offset' + ['Width', 'Height'][options.ort]];
+		var rect = scope_Base.getBoundingClientRect();
+		return options.ort === 0 ? rect.width : rect.height;
 	}
 
 	// External event handling


### PR DESCRIPTION
fixing baseSize() to work when a parent element has a css transform scale applied. Fixes slider position events as a result.