### PR TITLE
Add .noUi-handle to GPU layer

### DIFF
--- a/src/nouislider.css
+++ b/src/nouislider.css
@@ -51,7 +51,8 @@
 /* Painting and performance;
  * Browsers can paint handles in their own layer.
  */
-.noUi-base {
+.noUi-base,
+.noUi-handle {
 	-webkit-transform: translate3d(0,0,0);
 	transform: translate3d(0,0,0);
 }


### PR DESCRIPTION
Due to .noUi-handle and .noUi-base in different rendering layers we can get glitch artefacts like this: http://snpy.in/gqQCg3 http://snpy.in/BNr1NM (all ui elements must be in orange color)