### PR TITLE
Allow reading of noUiSlider instance's options

### DIFF
--- a/src/js/scope.js
+++ b/src/js/scope.js
@@ -285,7 +285,8 @@
 		off: removeEvent,
 		get: valueGet,
 		set: valueSet,
-		updateOptions: updateOptions
+		updateOptions: updateOptions,
+		options: options
 	};
 
 	// Attach user events.


### PR DESCRIPTION
After running noUiSlider on an element, you can now read the `options` object that was used to create each noUiSlider instance. The available `options` object stays up-to-date even after a call to `updateOptions`.