### PR TITLE
perf(spread/pips): use a buffer and use innerHTML only once

### DIFF
--- a/src/js/pips.js
+++ b/src/js/pips.js
@@ -163,7 +163,8 @@
 	function addMarking ( spread, filterFunc, formatter ) {
 
 		var style = ['horizontal', 'vertical'][options.ort],
-			element = document.createElement('div');
+			element = document.createElement('div'),
+			out = '';
 
 		addClass(element, cssClasses[20]);
 		addClass(element, cssClasses[20] + '-' + style);
@@ -189,11 +190,11 @@
 			values[1] = (values[1] && filterFunc) ? filterFunc(values[0], values[1]) : values[1];
 
 			// Add a marker for every point
-			element.innerHTML += '<div ' + getTags(offset, cssClasses[21], values) + '></div>';
+			out += '<div ' + getTags(offset, cssClasses[21], values) + '></div>';
 
 			// Values are only appended for points marked '1' or '2'.
 			if ( values[1] ) {
-				element.innerHTML += '<div '+getTags(offset, cssClasses[22], values)+'>' + formatter.to(values[0]) + '</div>';
+				out += '<div '+getTags(offset, cssClasses[22], values)+'>' + formatter.to(values[0]) + '</div>';
 			}
 		}
 
@@ -201,6 +202,7 @@
 		Object.keys(spread).forEach(function(a){
 			addSpread(a, spread[a]);
 		});
+		element.innerHTML = out;
 
 		return element;
 	}

--- a/src/js/scope.js
+++ b/src/js/scope.js
@@ -153,11 +153,7 @@
 
 	// Removes classes from the root and empties it.
 	function destroy ( ) {
-		cssClasses.forEach(function(cls){
-			if ( !cls ) { return; } // Ignore empty classes
-			removeClass(scope_Target, cls);
-		});
-		scope_Target.innerHTML = '';
+		while (scope_Target.firstChild) scope_Target.removeChild(scope_Target.firstChild);
 		delete scope_Target.noUiSlider;
 	}
 


### PR DESCRIPTION
Before:

![2016-02-11-160347_397x398_scrot](https://cloud.githubusercontent.com/assets/123822/12982234/39ef1ee4-d0e4-11e5-890c-0401bc4b02d6.png)

After:

![2016-02-11-160444_211x322_scrot](https://cloud.githubusercontent.com/assets/123822/12982236/3d3066bc-d0e4-11e5-99a7-ca9efe49832c.png)

Measured on the test page with console.time