### PR TITLE
Anonymous loading mismatch

### DIFF
--- a/src/js/intro.js
+++ b/src/js/intro.js
@@ -3,7 +3,7 @@
     if ( typeof define === 'function' && define.amd ) {
 
         // AMD. Register as an anonymous module.
-        define([], factory);
+        define('noUiSlider', factory);
 
     } else if ( typeof exports === 'object' ) {
 


### PR DESCRIPTION
I get a mismatch error with the anonymous loading, we don't use requirejs but it's included in some legacy code. I'm no requirejs expert but believe it should be named from reading the documentation http://requirejs.org/docs/whyamd.html#definition

http://requirejs.org/docs/errors.html#mismatch

It can then be used like so:
  require(['noUiSlider'], function (noUiSlider) {
        window.noUiSlider = noUiSlider;
      });