### PR TITLE
Fix jshint errors on grunt build

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "grunt-contrib-concat": "^0.5.0",
     "grunt-contrib-copy": "^0.5.0",
     "grunt-contrib-cssmin": "^0.10.0",
-    "grunt-contrib-jshint": "^0.10.0",
+    "grunt-contrib-jshint": "^0.11.3",
     "grunt-contrib-uglify": "^0.5.1",
     "onchange": "2.0.0",
     "simulant": "0.1.5"


### PR DESCRIPTION
Receiving this error when trying to grunt:
```
grunt
Running "concat:basic" (concat) task
File distribute/nouislider.js created.

Running "concat:css" (concat) task
File distribute/nouislider.css created.

Running "jshint:basic" (jshint) task
Warning: Path must be a string. Received null Use --force to continue.

Aborted due to warnings.
```

Issue stems from outdated grunt jshint package per https://github.com/jshint/jshint/issues/2922

Updated package.json resolves issue