### PR TITLE
change license info to SPDX identifier

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,7 +18,7 @@
 		"**/.*",
 		"**/*.json"
 	],
-	"license": "http://www.wtfpl.net/about/",
+	"license": "WTFPL",
 	"homepage": "http://refreshless.com/nouislider/",
 	"author": {
 		"name": "Leon Gersen"


### PR DESCRIPTION
The original reason for the PR is that nouislider cannot be deployed as a webjar since webjars.org website does not understand the license link. 

Bower has changed the format spec to use SPDX identifiers hence the change in the bower.json. See https://github.com/bower/bower/issues/895 for details.