### PR TITLE
Add 'padding' as a new option

### DIFF
--- a/documentation/slider-options.php
+++ b/documentation/slider-options.php
@@ -170,6 +170,45 @@
 
 </section>
 
+<?php sect('padding'); ?>
+<h2>Padding</h2>
+
+<section>
+
+	<div class="view">
+
+		<p>Padding limits how close to the slider edges handles can be.</p>
+
+		<div class="example">
+			<div id="slider-padding"></div>
+			<span class="example-val" id="slider-padding-value-min"></span>
+			<span class="example-val" id="slider-padding-value-max"></span>
+			<?php run('padding'); ?>
+			<?php run('padding-link'); ?>
+		</div>
+
+		<div class="options">
+			<strong>Default</strong>
+			<div><em>0</em></div>
+
+			<strong>Accepted values</strong>
+			<div><code>number</code></div>
+		</div>
+	</div>
+
+	<div class="side">
+		<?php code('padding'); ?>
+
+		<div class="viewer-header">Show the slider value</div>
+
+		<div class="viewer-content">
+			<?php code('padding-link'); ?>
+		</div>
+	</div>
+
+</section>
+
+
 
 <?php sect('step'); ?>
 <h2>Step</h2>

--- a/documentation/slider-options/padding-link.js
+++ b/documentation/slider-options/padding-link.js
@@ -1,0 +1,10 @@
+var paddingMin = document.getElementById('slider-padding-value-min'),
+	paddingMax = document.getElementById('slider-padding-value-max');
+
+paddingSlider.noUiSlider.on('update', function ( values, handle ) {
+	if ( handle ) {
+		marginMax.innerHTML = values[handle];
+	} else {
+		marginMin.innerHTML = values[handle];
+	}
+});

--- a/documentation/slider-options/padding.js
+++ b/documentation/slider-options/padding.js
@@ -1,0 +1,10 @@
+var paddingSlider = document.getElementById('slider-padding');
+
+noUiSlider.create(paddingSlider, {
+	start: [ 20, 80 ],
+	padding: 10,
+	range: {
+		'min': 0,
+		'max': 100
+	}
+});

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -165,6 +165,23 @@
 		}
 	}
 
+	function testPadding ( parsed, entry ) {
+
+		if ( !isNumeric(entry) ){
+			throw new Error("noUiSlider: 'padding' option must be numeric.");
+		}
+
+		if ( entry === 0 ) {
+			return;
+		}
+
+		parsed.padding = parsed.spectrum.getMargin(entry);
+
+		if ( !parsed.padding ) {
+			throw new Error("noUiSlider: 'padding' option is only supported on linear sliders.");
+		}
+	}
+
 	function testDirection ( parsed, entry ) {
 
 		// Set direction as a numerical value for easy parsing.
@@ -305,6 +322,7 @@
 		var parsed = {
 			margin: 0,
 			limit: 0,
+			padding: 0,
 			animate: true,
 			animationDuration: 300,
 			format: defaultFormatter
@@ -323,6 +341,7 @@
 			'orientation': { r: false, t: testOrientation },
 			'margin': { r: false, t: testMargin },
 			'limit': { r: false, t: testLimit },
+			'padding': { r: false, t: testPadding },
 			'behaviour': { r: true, t: testBehaviour },
 			'format': { r: false, t: testFormat },
 			'tooltips': { r: false, t: testTooltips },

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -180,6 +180,14 @@
 		if ( !parsed.padding ) {
 			throw new Error("noUiSlider: 'padding' option is only supported on linear sliders.");
 		}
+
+		if ( parsed.padding < 0 ) {
+			throw new Error("noUiSlider: 'padding' option must be a positive number.");
+		}
+
+		if ( parsed.padding >= 50 ) {
+			throw new Error("noUiSlider: 'padding' option must be less than half the range.");
+		}
 	}
 
 	function testDirection ( parsed, entry ) {

--- a/src/js/range.js
+++ b/src/js/range.js
@@ -230,7 +230,7 @@
 		var step = this.xNumSteps[0];
 
 		if ( step && (value % step) ) {
-			throw new Error("noUiSlider: 'limit' and 'margin' must be divisible by step.");
+			throw new Error("noUiSlider: 'limit', 'margin' and 'padding' must be divisible by step.");
 		}
 
 		return this.xPct.length === 2 ? fromPercentage(this.xVal, value) : false;

--- a/src/js/scope.js
+++ b/src/js/scope.js
@@ -29,6 +29,19 @@
 			}
 		}
 
+		// The padding option keeps the handles a certain distance from the
+		// edges of the slider. Padding must be > 0.
+		if ( options.padding ) {
+
+			if ( lookBackward && handleNumber === 0 ) {
+				to = Math.max(to, options.padding);
+			}
+
+			if ( lookForward && handleNumber === scope_Handles.length - 1 ) {
+				to = Math.min(to, 100 - options.padding);
+			}
+		}
+
 		to = scope_Spectrum.getStep(to);
 
 		// Limit percentage to the 0 - 100 range
@@ -301,7 +314,7 @@
 		});
 	}
 
-	// Updateable: margin, limit, step, range, animate, snap
+	// Updateable: margin, limit, padding, step, range, animate, snap
 	function updateOptions ( optionsToUpdate, fireSetEvent ) {
 
 		// Spectrum is created using the range, snap, direction and step options.
@@ -309,7 +322,7 @@
 		// If 'snap' and 'step' are not passed, they should remain unchanged.
 		var v = valueGet();
 
-		var updateAble = ['margin', 'limit', 'range', 'animate', 'snap', 'step', 'format'];
+		var updateAble = ['margin', 'limit', 'padding', 'range', 'animate', 'snap', 'step', 'format'];
 
 		// Only change options that we're actually passed to update.
 		updateAble.forEach(function(name){
@@ -332,9 +345,10 @@
 		newOptions.spectrum.direction = scope_Spectrum.direction;
 		scope_Spectrum = newOptions.spectrum;
 
-		// Limit and margin depend on the spectrum but are stored outside of it. (#677)
+		// Limit, margin and padding depend on the spectrum but are stored outside of it. (#677)
 		options.margin = newOptions.margin;
 		options.limit = newOptions.limit;
+		options.padding = newOptions.padding;
 
 		// Invalidate the current positioning so valueSet forces an update.
 		scope_Locations = [];

--- a/src/js/scope.js
+++ b/src/js/scope.js
@@ -33,11 +33,11 @@
 		// edges of the slider. Padding must be > 0.
 		if ( options.padding ) {
 
-			if ( lookBackward && handleNumber === 0 ) {
+			if ( handleNumber === 0 ) {
 				to = Math.max(to, options.padding);
 			}
 
-			if ( lookForward && handleNumber === scope_Handles.length - 1 ) {
+			if ( handleNumber === scope_Handles.length - 1 ) {
 				to = Math.min(to, 100 - options.padding);
 			}
 		}

--- a/tests/slider_padding.js
+++ b/tests/slider_padding.js
@@ -1,0 +1,37 @@
+
+	QUnit.test( "Padding option", function( assert ){
+
+		Q.innerHTML = '<div class="slider"></div>';
+
+		var settings = {
+			start: [ 0, 10 ],
+			padding: 1,
+			range: {
+				'min': 0,
+				'max': 10
+			}
+		};
+
+		var slider = Q.querySelector('.slider');
+
+		noUiSlider.create(slider, settings);
+
+		assert.deepEqual( slider.noUiSlider.get(), ['1.00', '9.00'], 'Padding applied on init.' );
+
+		slider.noUiSlider.set( [ 2, 10 ] );
+		assert.deepEqual( slider.noUiSlider.get(), ['2.00', '9.00'], 'Handle can\'t pass padding.' );
+
+		slider.noUiSlider.set( [ 0, 10 ] );
+		assert.deepEqual( slider.noUiSlider.get(), ['1.00', '9.00'], 'Multiple set outside of padding' );
+
+		// Rebuild with new settings;
+		settings.direction = 'rtl';
+		slider.noUiSlider.destroy();
+
+		noUiSlider.create(slider, settings);
+
+		assert.deepEqual( slider.noUiSlider.get(), ['1.00', '9.00'], 'RTL on init.' );
+
+		slider.noUiSlider.set( [ 3, 10 ] );
+		assert.deepEqual( slider.noUiSlider.get(), ['3.00', '9.00'], 'RTL set.' );
+	});


### PR DESCRIPTION
This `padding` option will keep the handles away from the slider edges. It follows in the footsteps of `margin` and `limit`, and uses the same `spectrum.getMargin()` function to format the value.

I'm not tied to the name 'padding' if you don't like it or think of something better, just let me know :smirk:. I'm also willing to add any documentation to the website if you'd like.

Here is an example that keeps the handle 1 tick away from the edges allowing a minimum of 1 and maximum of 9.

``` javascript
noUiSlider.create(rangeSlider, {
    start: [5],
    padding: 1,
    step: 1,
    range: {
        'min': 0,
        'max': 10,
    },
});
```

```
Start  value   Minimum value   Maximum value
|----[]----|   |-[]--------|   |--------[]-|
```

P.S. Thank you so much for the update allowing more than two handles! This is exactly what I was looking for and it also comes with a ton of extra features! I'm very impressed with all the time you put in to build this and continue to put in for maintenance. Thank you!
