### PR TITLE
Increases padding-top for example class wrapper.

### DIFF
--- a/documentation/assets/base.css
+++ b/documentation/assets/base.css
@@ -133,7 +133,7 @@
 
 	.example {
 		position: relative;
-		padding: 20px 60px 50px 30px;
+		padding: 40px 60px 50px 30px;
 		margin: 20px 0;
 		overflow: hidden;
 	}
@@ -338,7 +338,7 @@
 	.noUi-tooltip {
 		font: 700 12px/12px Arial;
 	}
-	
+
 @media ( min-width: 800px ) {
 
 	.index-demo {


### PR DESCRIPTION
`noUi-tooltip` is hidden because the `.example` div wrapper doesn't have enough height.