### PR TITLE
Fixes no `grunt lint` when `npm test`, uses `grunt test` instead

### DIFF
--- a/distribute/nouislider.css
+++ b/distribute/nouislider.css
@@ -1,4 +1,4 @@
-/*! nouislider - 9.2.0 - 2017-01-11 10:35:35 */
+/*! nouislider - 9.2.1 - 2017-03-16 20:53:40 */
 /* Functional styling;
  * These styles are required for noUiSlider to function.
  * You don't need to change these rules to apply your design.

--- a/distribute/nouislider.js
+++ b/distribute/nouislider.js
@@ -1,4 +1,4 @@
-/*! nouislider - 9.2.0 - 2017-01-11 10:35:34 */
+/*! nouislider - 9.2.1 - 2017-03-16 20:53:40 */
 
 (function (factory) {
 
@@ -22,7 +22,7 @@
 
 	'use strict';
 
-	var VERSION = '9.2.0';
+	var VERSION = '9.2.1';
 
 
 	// Creates a node, adds it to target, returns the new node.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nouislider",
-  "version": "9.2.0",
+  "version": "9.2.1",
   "main": "distribute/nouislider",
   "style": "distribute/nouislider.min.css",
   "license": "WTFPL",
@@ -8,7 +8,7 @@
     "build": "grunt create",
     "watch:js": "npm run build && onchange 'src/js/*.js' 'src/*.css' -- npm run build",
     "serve-tests": "browser-sync start --server . --startPath tests/slider.html --files 'distribute/, tests/*.js'",
-    "test": "grunt lint",
+    "test": "grunt test",
     "dev": "./scripts/dev.sh"
   },
   "devDependencies": {


### PR DESCRIPTION
New bug fix version increment