### PR TITLE
Pips: Check error condition; Avoid calculating with and comparing floats

### DIFF
--- a/src/js/pips.js
+++ b/src/js/pips.js
@@ -8,21 +8,24 @@
 
 		if ( mode === 'count' ) {
 
-			if ( !values ) {
-				throw new Error("noUiSlider (" + VERSION + "): 'values' required for mode 'count'.");
+			var intervals = values - 1;
+
+			if ( intervals < 1 ) {
+				throw new Error("noUiSlider (" + VERSION + "): 'values' (>= 2) required for mode 'count'.");
 			}
 
 			// Divide 0 - 100 in 'count' parts.
-			var spread = ( 100 / (values - 1) );
-			var v;
-			var i = 0;
+			var spread = ( 100 / intervals );
 
+			var i = 0;
 			values = [];
 
 			// List these parts and have them handled as 'positions'.
-			while ( (v = i++ * spread) <= 100 ) {
-				values.push(v);
+			while ( i < intervals ) {
+				values.push(i++ * spread);
 			}
+
+			values.push(100);
 
 			mode = 'positions';
 		}

--- a/src/js/pips.js
+++ b/src/js/pips.js
@@ -8,21 +8,19 @@
 
 		if ( mode === 'count' ) {
 
-			var intervals = values - 1;
-
-			if ( intervals < 1 ) {
+			if ( values < 2 ) {
 				throw new Error("noUiSlider (" + VERSION + "): 'values' (>= 2) required for mode 'count'.");
 			}
 
 			// Divide 0 - 100 in 'count' parts.
-			var spread = ( 100 / intervals );
+			var interval = values - 1;
+			var spread = ( 100 / interval );
 
-			var i = 0;
 			values = [];
 
 			// List these parts and have them handled as 'positions'.
-			while ( i < intervals ) {
-				values.push(i++ * spread);
+			while ( interval-- ) {
+				values[ interval ] = ( interval * spread );
 			}
 
 			values.push(100);

--- a/tests/addon_pips.js
+++ b/tests/addon_pips.js
@@ -98,19 +98,28 @@
 
 		var slider = test_slider({
 			mode: 'count',
-			values: 8
+			values: 12
 		});
 
 	// COUNT
 
-		assert.equal( Q.querySelectorAll('.noUi-value').length, 8, 'Placed requested number of values' );
+		assert.equal( Q.querySelectorAll('.noUi-value').length, 12, 'Placed requested number of values' );
 
 		var pos2 = [];
 		Array.prototype.forEach.call(Q.querySelectorAll('.noUi-value'), function( el ){
 			pos2.push(parseInt(el.style.left));
 		});
 
-		assert.deepEqual(pos2, [0, Math.floor((100/7)*1), Math.floor((100/7)*2), Math.floor((100/7)*3), Math.floor((100/7)*4), Math.floor((100/7)*5), Math.floor((100/7)*6), 100], 'Values spread evenly');
+		assert.deepEqual( pos2, [0, Math.floor( (100 / 11) * 1 ), Math.floor( (100 / 11) * 2 ), Math.floor( (100 / 11) * 3 ), Math.floor( (100 / 11) * 4 ), Math.floor( (100 / 11) * 5 ), Math.floor( (100 / 11) * 6 ), Math.floor( (100 / 11) * 7 ), Math.floor( (100 / 11) * 8 ), Math.floor( (100 / 11) * 9 ), Math.floor( (100 / 11) * 10 ), 100], 'Values spread evenly' );
+
+	} );
+
+	QUnit.test( "Count, values >= 2", function (assert) {
+
+		assert.throws( function() { test_slider( {
+			mode: 'count',
+			values: 1
+		} ) }, 'Checks minimum number of values' );
 
 	});
 


### PR DESCRIPTION
This PR addresses two issues on pip options:
1. For  `values === 1` division by zero causes `spread` to become `Infinity`, which later on leads to `v` becoming `NaN`. Result: No pips shown.
2. For `values === 12` `spread` becomes 9.090909090909092. Multiplication with 11 in the loop yields 100.00000000000001, which is not `<= 100`. Result: Last pip not shown.