### PR TITLE
look ahead when applying values

### DIFF
--- a/distribute/nouislider.js
+++ b/distribute/nouislider.js
@@ -2056,7 +2056,7 @@ function closure ( target, options, originalOptions ){
 
 		// Now that all base values are set, apply constraints
 		scope_HandleNumbers.forEach(function(handleNumber){
-			setHandle(handleNumber, scope_Locations[handleNumber], true, false);
+			setHandle(handleNumber, scope_Locations[handleNumber], true, true);
 		});
 
 		setZindex();

--- a/src/js/scope.js
+++ b/src/js/scope.js
@@ -1,4 +1,3 @@
-
 	// Split out the handle positioning logic so the Move event can use it, too
 	function checkHandlePosition ( reference, handleNumber, to, lookBackward, lookForward, getValue ) {
 
@@ -177,7 +176,7 @@
 
 		// Now that all base values are set, apply constraints
 		scope_HandleNumbers.forEach(function(handleNumber){
-			setHandle(handleNumber, scope_Locations[handleNumber], true, false);
+			setHandle(handleNumber, scope_Locations[handleNumber], true, true);
 		});
 
 		setZindex();


### PR DESCRIPTION
Fixes #823 

Look ahead when applying values to prevent lower handle from taking positions past where it should.