### PR TITLE
npm: include only distribution files

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,4 +31,7 @@
     "type": "git",
     "url": "git://github.com/leongersen/noUiSlider.git"
   }
+  "files": [
+    "distribute"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "repository": {
     "type": "git",
     "url": "git://github.com/leongersen/noUiSlider.git"
-  }
+  },
   "files": [
     "distribute"
   ]


### PR DESCRIPTION
When installed with npm, it will add all files that you see in this repository.
I've added "files" option, so only the necessary production files are installed.
Please commit this asap on npm as  it's really something that most developers will welcome.  Who don't like to keep their projects clean?

Thank you.
