### PR TITLE
Ensure clicks on .noUi-base pseudo-elements update value. Fixes #842.

### DIFF
--- a/src/js/scope_helpers.js
+++ b/src/js/scope_helpers.js
@@ -147,7 +147,7 @@
 		// Clamp proposal between 0% and 100%
 		// Out-of-bound coordinates may occur when .noUi-base pseudo-elements 
 		// are used (e.g. contained handles feature)
-		proposal = Math.max(0, Math.min(100, proposal));
+		proposal = limit(proposal);
 
 		return options.dir ? 100 - proposal : proposal;
 	}

--- a/src/js/scope_helpers.js
+++ b/src/js/scope_helpers.js
@@ -144,11 +144,10 @@
 		var location = calcPoint - offset(scope_Base, options.ort);
 		var proposal = ( location * 100 ) / baseSize();
 
-		// If a .noUi-base pseudo-element is clicked (e.g. for contained handles), 
-		// the proposed percentage should never exceed 100. (see #842)
-		if ( proposal > 100 ) {
-			proposal = 100;
-		}
+		// Clamp proposal between 0% and 100%
+		// Out-of-bound coordinates may occur when .noUi-base pseudo-elements 
+		// are used (e.g. contained handles feature)
+		proposal = Math.max(0, Math.min(100, proposal));
 
 		return options.dir ? 100 - proposal : proposal;
 	}

--- a/src/js/scope_helpers.js
+++ b/src/js/scope_helpers.js
@@ -143,6 +143,13 @@
 	function calcPointToPercentage ( calcPoint ) {
 		var location = calcPoint - offset(scope_Base, options.ort);
 		var proposal = ( location * 100 ) / baseSize();
+
+		// If a .noUi-base pseudo-element is clicked (e.g. for contained handles), 
+		// the proposed percentage should never exceed 100. (see #842)
+		if ( proposal > 100 ) {
+			proposal = 100;
+		}
+
 		return options.dir ? 100 - proposal : proposal;
 	}
 
@@ -161,7 +168,7 @@
 
 			var pos = Math.abs(scope_Locations[index] - proposal);
 
-			if ( pos < closest ) {
+			if ( pos < closest || (pos === 100 && closest === 100) ) {
 				handleNumber = index;
 				closest = pos;
 			}

--- a/tests/slider.html
+++ b/tests/slider.html
@@ -68,6 +68,7 @@
 	<script src="slider_binding.js"></script>
 	<script src="slider_update-numbers.js"></script>
 	<script src="slider_three_or_more_handles.js"></script>
+	<script src="slider_contained_handles.js"></script>
 	<script src="slider_lookaround.js"></script>
 
 	<script src="addon_pips.js"></script>

--- a/tests/slider_contained_handles.js
+++ b/tests/slider_contained_handles.js
@@ -60,4 +60,8 @@
 		simulateMousedown(base, rect.x + rect.width - 1, midY);
 		assert.strictEqual(slider.noUiSlider.get(), '100.00', 'Click near right edge should update value to 100');
 
+		// Click leftmost edge again
+		simulateMousedown(base, rect.x + 1, midY);
+		assert.strictEqual(slider.noUiSlider.get(), '0.00', 'Click near left edge should update value to 0');
+
 	});

--- a/tests/slider_contained_handles.js
+++ b/tests/slider_contained_handles.js
@@ -1,0 +1,63 @@
+	function simulateMousedown(clickTarget, x, y) {
+		// Based on https://stackoverflow.com/a/19570419/1367431
+		var clickEvent= document.createEvent('MouseEvents');
+		clickEvent.initMouseEvent(
+			'mousedown', true, true, window, 0,
+			0, 0, x, y, false, false,
+			false, false, 0, null
+		);
+		clickTarget.dispatchEvent(clickEvent);
+	}
+
+	QUnit.test( "Slider with contained handles", function( assert ){
+
+		Q.innerHTML = '\
+			<div id="slider1" class="contained-handles"></div>\
+			<style>\
+				.noUi-target {\
+				    padding: 0 16px;\
+				}\
+				.noUi-base:before {\
+					content: "";\
+					width: calc(100% + 34px);\
+					height: 100%;\
+					position: absolute;\
+					top: 0;\
+					left: -17px;\
+					display: block;\
+					background: red;\
+				}\
+			</style>\
+		';
+
+		var slider = document.getElementById('slider1');
+
+		noUiSlider.create(slider, {
+			start: 50,
+			connect: [true, false],
+			range: {
+				'min': 0,
+				'max': 100
+			},
+			animate: false,
+			animationDuration: 0
+		});
+
+		// Click the leftmost edge of the bar
+		var rect = slider.getBoundingClientRect(),
+			base = slider.querySelector('.noUi-base'),
+			midY = rect.y + rect.height / 2;
+
+		// These clicks aren't on .noUi-base itself but rather its child pseudo-elements.
+		// The "contained handles" style relies on clickable pseudo-elements. If the click is 
+		// outside the bounds of .noUi-base, it should snap to the end (0% or 100%).
+
+		// Click on leftmost edge of slider. 
+		simulateMousedown(base, rect.x + 1, midY);
+		assert.strictEqual(slider.noUiSlider.get(), '0.00', 'Click near left edge should update value to 0');
+
+		// Click on rightmost edge of slider
+		simulateMousedown(base, rect.x + rect.width - 1, midY);
+		assert.strictEqual(slider.noUiSlider.get(), '100.00', 'Click near right edge should update value to 100');
+
+	});


### PR DESCRIPTION
Solves bug where pseudo-elements can be used for 'contained handles' styles but
cannot be reliably clicked on if outside the bounds of .noUi-base