### PR TITLE
Remove padding must be > 50% range test

### DIFF
--- a/src/js/options.js
+++ b/src/js/options.js
@@ -214,10 +214,6 @@
 		if ( parsed.padding[0] < 0 || parsed.padding[1] < 0 ) {
 			throw new Error("noUiSlider (" + VERSION + "): 'padding' option must be a positive number(s).");
 		}
-
-		if ( parsed.padding[0] >= 50 || parsed.padding[1] >= 50 ) {
-			throw new Error("noUiSlider (" + VERSION + "): 'padding' option must be less than half the range.");
-		}
 	}
 
 	function testDirection ( parsed, entry ) {


### PR DESCRIPTION
I ran into an issue trying to create sliders like:

```js
var slider = document.getElementById('slider');

noUiSlider.create(slider, {
  start: [14, 18],
  range: {
    min: 0,
    max: 18
  },
  padding: [12, 0],
  step: 1
});
```

Where padding exceeds half the range which causes the:

```
'padding' option must be less than half the range.
```

error. I tested removing this option in my application and didn't see any negative side effects and thought I would PR it. This doesn't seems to cause any tests to fail.