### PR TITLE
replace `innerText` to `textContent` for old Firefox

### DIFF
--- a/src/js/pips.js
+++ b/src/js/pips.js
@@ -219,7 +219,7 @@
 				node.className = getClasses(values[1], options.cssClasses.value);
 				node.setAttribute('data-value', values[0]);
 				node.style[options.style] = offset + '%';
-				node.innerText = formatter.to(values[0]);
+				node.textContent = formatter.to(values[0]);
 			}
 		}
 


### PR DESCRIPTION
`Node.innerText` not work in Firefox 44-.

As I understand it, the setter `innerText` and `textContent` they do not differ.
