### PR TITLE
Remove wrong URL to full list of class names

### DIFF
--- a/documentation/more/classes.js
+++ b/documentation/more/classes.js
@@ -9,6 +9,6 @@ noUiSlider.create(slider, {
         // Full list of classnames to override.
         // Does NOT extend the default classes.
         // Have a look at the source for the full, current list:
-        // https://github.com/leongersen/noUiSlider/blob/master/src/js/options.js#L398
+        // https://github.com/leongersen/noUiSlider/blob/master/src/nouislider.js#L880
     }
 });


### PR DESCRIPTION
This pull request fixes the worng URL to the full list of class names mentioned in  issue https://github.com/leongersen/noUiSlider/issues/950.