### PR TITLE
Fix #961

### DIFF
--- a/src/nouislider.js
+++ b/src/nouislider.js
@@ -2258,6 +2258,14 @@
             var increment = nearbySteps.thisStep.step;
             var decrement = null;
 
+            // If snapped, directly use defined step value
+            if (options.snap) {
+                return [
+                    value - nearbySteps.stepBefore.startValue || null,
+                    nearbySteps.stepAfter.startValue - value || null
+                ];
+            }
+            
             // If the next value in this step moves into the next step,
             // the increment is the start of the next step - the current value
             if (increment !== false) {


### PR DESCRIPTION
This would bring the correct behaviour when snap and range is defined.

One small caveat with this implementation is that if two consecutive steps define the same value, then the keyboard will get stuck. At this point it might be considered user mis-usage.