### PR TITLE
Update nouislider.js - accessibility optimization

### DIFF
--- a/src/nouislider.js
+++ b/src/nouislider.js
@@ -507,11 +507,11 @@
         throw new Error("noUiSlider (" + VERSION + "): 'format' requires 'to' and 'from' methods.");
     }
 
-    function testDefault( parsed, entry) {
+    function testDefault(parsed, entry) {
         if (!isNumeric(entry)) {
             throw new Error("noUiSlider (" + VERSION + "): 'default' is not numeric.");
         }
-    	parsed.default = entry;
+        parsed.default = entry;
     }
 
     function testStep(parsed, entry) {
@@ -856,7 +856,7 @@
         // Tests are executed in the order they are presented here.
         var tests = {
             step: { r: false, t: testStep },
-        default: { r: false, t: testDefault },
+            default: { r: false, t: testDefault },
             start: { r: true, t: testStart },
             connect: { r: true, t: testConnect },
             direction: { r: true, t: testDirection },
@@ -1805,30 +1805,30 @@
 
             var horizontalKeys = ["Left", "Right"];
             var verticalKeys = ["Down", "Up"];
-            var largeStepKeys = [ "PageDown", "PageUp"];
-            var edgeKeys = [ "Home", "End"];
-            
-            if( !options.dir && !options.ort) {
-            	// left to right:
-            	verticalKeys.reverse();
-            	largeStepKeys.reverse();
-            } else if( options.dir && !options.ort) {
-            	// right to left slider: 
+            var largeStepKeys = ["PageDown", "PageUp"];
+            var edgeKeys = ["Home", "End"];
+
+            if (!options.dir && !options.ort) {
+                // left to right:
+                verticalKeys.reverse();
+                largeStepKeys.reverse();
+            } else if (options.dir && !options.ort) {
+                // right to left slider:
                 horizontalKeys.reverse();
-            	verticalKeys.reverse();
-            	largeStepKeys.reverse();
-            } else if( !options.dir && options.ort) {
-            	// top down:
-            	verticalKeys.reverse();
-            	largeStepKeys.reverse();
-            } else if( options.dir && options.ort) {
-            	// bottom up: 
-            	edgeKeys.reverse();
+                verticalKeys.reverse();
+                largeStepKeys.reverse();
+            } else if (!options.dir && options.ort) {
+                // top down:
+                verticalKeys.reverse();
+                largeStepKeys.reverse();
+            } else if (options.dir && options.ort) {
+                // bottom up:
+                edgeKeys.reverse();
             }
 
             // Strip "Arrow" for IE compatibility. https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key
             var key = event.key.replace("Arrow", "");
-            
+
             var isDown = key === verticalKeys[0] || key === horizontalKeys[0];
             var isUp = key === verticalKeys[1] || key === horizontalKeys[1];
             var isLargeDown = key === largeStepKeys[0];
@@ -1841,63 +1841,63 @@
 
             event.preventDefault();
 
-            if( isUp || isDown || isLargeUp || isLargeDown) {
-            var multiplier = 5;
-            var direction = (isDown || isLargeDown)? 0 : 1;
-            var steps = getNextStepsForHandle(handleNumber);
-            var step = steps[direction];
+            if (isUp || isDown || isLargeUp || isLargeDown) {
+                var multiplier = 5;
+                var direction = isDown || isLargeDown ? 0 : 1;
+                var steps = getNextStepsForHandle(handleNumber);
+                var step = steps[direction];
 
-            // At the edge of a slider, do nothing
-            if (step === null) {
-                return false;
-            }
+                // At the edge of a slider, do nothing
+                if (step === null) {
+                    return false;
+                }
 
-            // No step set, use the default of 10% of the sub-range
-            if (step === false) {
-                step = scope_Spectrum.getDefaultStep(scope_Locations[handleNumber], isDown || isLargeDown, 10);
-            }
+                // No step set, use the default of 10% of the sub-range
+                if (step === false) {
+                    step = scope_Spectrum.getDefaultStep(scope_Locations[handleNumber], isDown || isLargeDown, 10);
+                }
 
-            if( isLargeUp || isLargeDown) {
-            	step *= multiplier;
-            }
-            // Step over zero-length ranges (#948);
-            step = Math.max(step, 0.0000001);
+                if (isLargeUp || isLargeDown) {
+                    step *= multiplier;
+                }
+                // Step over zero-length ranges (#948);
+                step = Math.max(step, 0.0000001);
 
-            // Decrement for down steps
-            step = ((isDown || isLargeDown)? -1 : 1) * step;
-            setHandle(handleNumber, scope_Spectrum.toStepping(scope_Values[handleNumber] + step), true, true);
+                // Decrement for down steps
+                step = (isDown || isLargeDown ? -1 : 1) * step;
+                setHandle(handleNumber, scope_Spectrum.toStepping(scope_Values[handleNumber] + step), true, true);
             } else {
-            	// home or end key were pressed
+                // home or end key were pressed
                 var minVal = options.spectrum.xVal[0];
-                var maxVal = options.spectrum.xVal[ options.spectrum.xVal.length -1];
-                var defaultVal = (options.default === undefined) ? minVal : options.default;
-                
+                var maxVal = options.spectrum.xVal[options.spectrum.xVal.length - 1];
+                var defaultVal = options.default === undefined ? minVal : options.default;
+
                 var currentVal = scope_Values[handleNumber];
-    var targetVal = currentVal;
-    if( defaultVal === minVal || defaultVal === maxVal) {
-    	// ignore defaultVal
-    	if( isMin) {
-    		targetVal = minVal;
-    	} else {
-    		targetVal = maxVal;
-    	}
-    } else {
-    	// check wether set to default value nor to min / max value
-    if( isMax) {
-    	if( currentVal < defaultVal) {
-    		targetVal = defaultVal;
-    	} else {
-    		targetVal = maxVal;
-    	}
-    } else {
-    	if( currentVal > defaultVal) {
-    		targetVal = defaultVal;
-    	} else {
-    		targetVal = minVal;
-    	}
-    }
-    }
-            setHandle(handleNumber, scope_Spectrum.toStepping( targetVal), true, true);
+                var targetVal = currentVal;
+                if (defaultVal === minVal || defaultVal === maxVal) {
+                    // ignore defaultVal
+                    if (isMin) {
+                        targetVal = minVal;
+                    } else {
+                        targetVal = maxVal;
+                    }
+                } else {
+                    // check wether set to default value nor to min / max value
+                    if (isMax) {
+                        if (currentVal < defaultVal) {
+                            targetVal = defaultVal;
+                        } else {
+                            targetVal = maxVal;
+                        }
+                    } else {
+                        if (currentVal > defaultVal) {
+                            targetVal = defaultVal;
+                        } else {
+                            targetVal = minVal;
+                        }
+                    }
+                }
+                setHandle(handleNumber, scope_Spectrum.toStepping(targetVal), true, true);
             }
 
             fireEvent("slide", handleNumber);

--- a/src/nouislider.js
+++ b/src/nouislider.js
@@ -1808,22 +1808,13 @@
             var largeStepKeys = ["PageDown", "PageUp"];
             var edgeKeys = ["Home", "End"];
 
-            if (!options.dir && !options.ort) {
-                // left to right:
-                verticalKeys.reverse();
-                largeStepKeys.reverse();
-            } else if (options.dir && !options.ort) {
-                // right to left slider:
+            if (options.dir && !options.ort) {
+                // On an right-to-left slider, the left and right keys act inverted
                 horizontalKeys.reverse();
+            } else if (options.ort && !options.dir) {
+                // On a top-to-bottom slider, the up and down keys act inverted
                 verticalKeys.reverse();
                 largeStepKeys.reverse();
-            } else if (!options.dir && options.ort) {
-                // top down:
-                verticalKeys.reverse();
-                largeStepKeys.reverse();
-            } else if (options.dir && options.ort) {
-                // bottom up:
-                edgeKeys.reverse();
             }
 
             // Strip "Arrow" for IE compatibility. https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key

--- a/src/nouislider.js
+++ b/src/nouislider.js
@@ -1853,22 +1853,16 @@
                 // Decrement for down steps
                 step = (isDown ? -1 : 1) * step;
 
-                to = scope_Spectrum.toStepping(scope_Values[handleNumber] + step);
+                to = scope_Values[handleNumber] + step;
+            } else if (isMax) {
+                // End key
+                to = options.spectrum.xVal[options.spectrum.xVal.length - 1];
             } else {
-                // home or end key were pressed
-                var minVal = options.spectrum.xVal[0];
-                var maxVal = options.spectrum.xVal[options.spectrum.xVal.length - 1];
-
-                if (isMax) {
-                    to = maxVal;
-                } else {
-                    to = minVal;
-                }
-
-                to = scope_Spectrum.toStepping(to);
+                // Home key
+                to = options.spectrum.xVal[0];
             }
 
-            setHandle(handleNumber, to, true, true);
+            setHandle(handleNumber, scope_Spectrum.toStepping(to), true, true);
 
             fireEvent("slide", handleNumber);
             fireEvent("update", handleNumber);


### PR DESCRIPTION
- Accessibility: added additional keyboard shortcuts: page up / page down to move slider handle in larger steps than with up/down and left / right keys (ratio 5x) and home / end keys to move slider handle between min / max values (range).
- noUiSlider.create() options: added "default" option (optional). With keyboard shortcuts home / end, the handle moves between min, default and max value . If default option value is not set or default equals min / max, home / end keypress moves between min/max.