### PR TITLE
Invert direction check logic

### DIFF
--- a/src/nouislider.js
+++ b/src/nouislider.js
@@ -1093,10 +1093,10 @@
 
             var textDirection = getComputedStyle(addTarget).direction;
 
-            if (textDirection === "ltr") {
-                addClass(addTarget, options.cssClasses.textDirectionLtr);
-            } else {
+            if (textDirection === "rtl") {
                 addClass(addTarget, options.cssClasses.textDirectionRtl);
+            } else {
+                addClass(addTarget, options.cssClasses.textDirectionLtr);
             }
 
             return addNodeTo(addTarget, options.cssClasses.base);


### PR DESCRIPTION
Invert ltr direction check to rtl to match defaults, addressing the case where the computed style doesn't yet contain a direction. Partial fix for #1038.