### PR TITLE
Add noUiSlider parameter to event callbacks

### DIFF
--- a/documentation/events-callbacks/binding.js
+++ b/documentation/events-callbacks/binding.js
@@ -4,7 +4,7 @@ function doSomething(values, handle, unencoded, tap, positions, noUiSlider) {
     // unencoded: Slider values without formatting (array);
     // tap: Event was caused by the user tapping the slider (boolean);
     // positions: Left offset of the handles (array);
-    // noUiSlider: slider public Api
+    // noUiSlider: slider public Api (noUiSlider);
 }
 
 // Binding signature

--- a/documentation/events-callbacks/binding.js
+++ b/documentation/events-callbacks/binding.js
@@ -1,9 +1,10 @@
-function doSomething(values, handle, unencoded, tap, positions) {
+function doSomething(values, handle, unencoded, tap, positions, noUiSlider) {
     // values: Current slider values (array);
     // handle: Handle that caused the event (number);
     // unencoded: Slider values without formatting (array);
     // tap: Event was caused by the user tapping the slider (boolean);
     // positions: Left offset of the handles (array);
+    // noUiSlider: slider public Api
 }
 
 // Binding signature

--- a/src/nouislider.js
+++ b/src/nouislider.js
@@ -1986,7 +1986,9 @@
                             // Event is fired by tap, true or false
                             tap || false,
                             // Left offset of the handle, in relation to the slider
-                            scope_Locations.slice()
+                            scope_Locations.slice(),
+                            // add the slider public API to an accessible parameter when this is unavailable
+                            scope_Self
                         );
                     });
                 }


### PR DESCRIPTION
Hi,

I've been working with noUiSlider in a Typescript context and when using arrow functions to define the callback i override this and therefore are unable to either access noUiSlider which caused the callback or the class i've called this from.

Hope I've provided changes in accordance to code style and also done sufficient changes to the documentation.