### PR TITLE
Shadow DOM: touchmove not working on mobile

### DIFF
--- a/src/nouislider.js
+++ b/src/nouislider.js
@@ -1519,7 +1519,7 @@
             if (touch) {
                 // Returns true if a touch originated on the target.
                 var isTouchOnTarget = function(checkTouch) {
-                    return checkTouch.target === eventTarget || eventTarget.contains(checkTouch.target);
+                    return checkTouch.target === eventTarget || eventTarget.contains(checkTouch.target) || (checkTouch.target.shadowRoot && checkTouch.target.shadowRoot.contains(eventTarget));
                 };
 
                 // In the case of touchstart events, we need to make sure there is still no more than one


### PR DESCRIPTION
I tried to use noUiSlider in a Stencil web component using the ShadowDOM (`shadow: true`) and noticed that the slider handle can't be dragged on mobile. If I disable the ShadowDOM in my web component, everything works fine. 

I traced this back to the function `isTouchOnTarget` that always returns `false` when it's called in the scope of `e.type === "touchmove"`. 

(Touch) events in the ShadowDOM are redirected to their host element. You can observe that `checktouch.Target` is the host element while `eventTarget` is the `handle div` within the shadow root of the component. Of course, the `div` does not contain the host element but it's actually the other way around. To check this, you have to call `contains` on the `shadowRoot` element in the host.

I'm not sure if there is a better approach to fix this but dragging on mobile does work now even in a shadowed web component.