### PR TITLE
Fix issue with pip type being incorrect when only single pip value should be shown at end of range

### DIFF
--- a/src/nouislider.js
+++ b/src/nouislider.js
@@ -1328,7 +1328,7 @@
                     type = group.indexOf(i) > -1 ? PIPS_LARGE_VALUE : isSteps ? PIPS_SMALL_VALUE : PIPS_NO_VALUE;
 
                     // Enforce the 'ignoreFirst' option by overwriting the type for 0.
-                    if (!index && ignoreFirst) {
+                    if (!index && ignoreFirst && i !== high) {
                         type = 0;
                     }
 

--- a/tests/addon_pips.js
+++ b/tests/addon_pips.js
@@ -148,6 +148,15 @@ QUnit.test("Pips: Values", function (assert) {
     assert.equal(document.getElementById('qunit-fixture').querySelectorAll('.noUi-value').length, 7, 'Placed requested number of values');
 });
 
+QUnit.test("Pips: Values", function(assert) {
+    var slider = test_slider({
+        mode: 'values',
+        values: [10000]
+    }, 0);
+
+    assert.equal(document.getElementById('qunit-fixture').querySelectorAll('.noUi-value').length, 1, 'Placed single value at end of range');
+});
+
 // VALUES (STEPPED)
 
 QUnit.test("Pips: Values, stepped", function (assert) {


### PR DESCRIPTION
This fixes issue https://github.com/leongersen/noUiSlider/issues/1062. From testing and my limited understanding of the code, nothing else seems to break.