### PR TITLE
Ignore erroneous tap events

### DIFF
--- a/src/nouislider.js
+++ b/src/nouislider.js
@@ -1855,6 +1855,13 @@
 
         // Move closest handle to tapped location.
         function eventTap(event) {
+            // Erroneous events seem to be passed in occasionally on iOS/iPadOS after user finishes interacting with 
+            // the slider. They appear to be of type MouseEvent, yet they don't have usual properties set. Ignore tap 
+            // events that have no touches or buttons associated with them.
+            if (!event.buttons && !event.touches) {
+                return false;
+            }
+
             // The tap event shouldn't propagate up
             event.stopPropagation();
 


### PR DESCRIPTION
Resolves #1057 by ignoring erroneous tap events, which occasionally get sent on iOS and iPadOS _after_ user finishes interacting with the slider.

Not sure if any OS/platform checks are needed here — I'm open to suggestions @leongersen. 🙃