### PR TITLE
added a step size multiplier config for page up/down

### DIFF
--- a/src/nouislider.js
+++ b/src/nouislider.js
@@ -653,6 +653,14 @@
         parsed.singleStep = entry;
     }
 
+    function testPageStep(parsed, entry) {
+        if (!isNumeric(entry)) {
+            throw new Error("noUiSlider (" + VERSION + "): 'pageStep' is not numeric.");
+        }
+
+        parsed.pageStep = entry;
+    }
+
     function testRange(parsed, entry) {
         // Filter incorrect input.
         if (typeof entry !== "object" || Array.isArray(entry)) {
@@ -986,6 +994,7 @@
         // Tests are executed in the order they are presented here.
         var tests = {
             step: { r: false, t: testStep },
+            pageStep: { r: false, t: testPageStep },
             start: { r: true, t: testStart },
             connect: { r: true, t: testConnect },
             direction: { r: true, t: testDirection },
@@ -1014,7 +1023,8 @@
             orientation: "horizontal",
             keyboardSupport: true,
             cssPrefix: "noUi-",
-            cssClasses: cssClasses
+            cssClasses: cssClasses,
+            pageStep: 5
         };
 
         // AriaFormat defaults to regular format, if any.
@@ -1942,7 +1952,7 @@
             var to;
 
             if (isUp || isDown) {
-                var multiplier = 5;
+                var multiplier = options.pageStep;
                 var direction = isDown ? 0 : 1;
                 var steps = getNextStepsForHandle(handleNumber);
                 var step = steps[direction];

--- a/tests/slider_keyboard.js
+++ b/tests/slider_keyboard.js
@@ -8,6 +8,14 @@ QUnit.test("Keyboard support", function (assert) {
         element.dispatchEvent(new KeyboardEvent('keydown', {'key': 'ArrowDown'}));
     }
 
+    function pageUp(element) {
+        element.dispatchEvent(new KeyboardEvent('keydown', {'key': 'PageUp'}));
+    }
+
+    function pageDown(element) {
+        element.dispatchEvent(new KeyboardEvent('keydown', {'key': 'PageDown'}));
+    }
+
     document.getElementById('qunit-fixture').innerHTML = '<div class="slider"></div>';
 
     var slider = document.getElementById('qunit-fixture').querySelector('.slider');
@@ -108,4 +116,26 @@ QUnit.test("Keyboard support", function (assert) {
 
     up(handle0);
     assert.deepEqual(slider.noUiSlider.get(), ['6.00', '6.00'], 'Handle 0 cannot push past handle 1');
+
+    slider.noUiSlider.destroy();
+
+    noUiSlider.create(slider, {
+        start: [5],
+        step: 1,
+        range: {
+            'min': 0,
+            'max': 10
+        },
+        pageStep: 2
+    });
+
+    assert.deepEqual(slider.noUiSlider.get(), '5.00');
+
+    handle0 = slider.querySelector('[data-handle="0"]');
+
+    pageDown(handle0);
+    assert.deepEqual(slider.noUiSlider.get(), '3.00');
+
+    pageUp(handle0);
+    assert.deepEqual(slider.noUiSlider.get(), '5.00');
 });


### PR DESCRIPTION
added an additional config for #1036 to allow for the page up/down keys to be configured with a multiplier besides 5.

closes #1083 