### PR TITLE
Implement .get(unencoded=false)

### DIFF
--- a/documentation/slider-read-write.php
+++ b/documentation/slider-read-write.php
@@ -18,7 +18,7 @@
 
 		<?php code('read'); ?>
 
-		<p>For one-handle sliders, calling <code>.get()</code> will return the value as a <code>'string'</code>. For multi-handle sliders, an <code>array['string', 'string', ...]</code> will be returned.</p>
+		<p>For one-handle sliders, calling <code>.get()</code> will return the value as a <code>'string'</code>. For multi-handle sliders, an <code>array['string', 'string', ...]</code> will be returned. To return the slider values as a <code>number</code> or <code>array[number, number, ...]</code> use <code>.get(true)</code>, which returns the unencoded values.</p>
 	</div>
 </section>
 

--- a/src/nouislider.ts
+++ b/src/nouislider.ts
@@ -188,7 +188,7 @@ export interface API {
     steps: () => NextStepsForHandle[];
     on: (eventName: string, callback: EventCallback) => void;
     off: (eventName: string) => void;
-    get: () => GetResult;
+    get: (unencoded?: boolean) => GetResult;
     set: (input: number | string | (number | string)[], fireSetEvent?: boolean, exactInput?: boolean) => void;
     setHandle: (handleNumber: number, value: number | string, fireSetEvent?: boolean, exactInput?: boolean) => void;
     reset: (fireSetEvent?: boolean) => void;
@@ -2733,7 +2733,11 @@ function scope(target: TargetElement, options: ParsedOptions, originalOptions: O
     }
 
     // Get the slider value.
-    function valueGet(): GetResult {
+    function valueGet(unencoded = false): GetResult {
+        if (unencoded) {
+            // return a copy of the raw values
+            return scope_Values.length === 1 ? scope_Values[0] : scope_Values.slice(0);
+        }
         const values = scope_Values.map(options.format.to);
 
         // If only one handle is used, return a single value.

--- a/tests/slider_three_or_more_handles.js
+++ b/tests/slider_three_or_more_handles.js
@@ -15,13 +15,13 @@ QUnit.test("Slider with three or more handles", function (assert) {
         }
     });
 
-    assert.deepEqual(slider.noUiSlider.get().map(Number), [5, 10, 15]);
+    assert.deepEqual(slider.noUiSlider.get(true), [5, 10, 15]);
 
     slider.noUiSlider.set([0, 0, 1]);
-    assert.deepEqual(slider.noUiSlider.get().map(Number), [0, 0, 1]);
+    assert.deepEqual(slider.noUiSlider.get(true), [0, 0, 1]);
 
     slider.noUiSlider.set([19, 20, 20]);
-    assert.deepEqual(slider.noUiSlider.get().map(Number), [19, 20, 20]);
+    assert.deepEqual(slider.noUiSlider.get(true), [19, 20, 20]);
 
 
     // xnakos spotted a bug where handles can stack wrong, so if there are

--- a/tests/slider_update.js
+++ b/tests/slider_update.js
@@ -17,6 +17,7 @@ QUnit.test("Testing update method", function (assert) {
     });
 
     assert.deepEqual(slider.noUiSlider.get(), '50');
+    assert.deepEqual(slider.noUiSlider.get(true), 50);
 
     slider.noUiSlider.destroy();
 

--- a/tests/slider_values.js
+++ b/tests/slider_values.js
@@ -20,9 +20,12 @@ QUnit.test("Values", function (assert) {
 
     assert.deepEqual(slider.noUiSlider.get(), ['50', '100'], 'Values where set');
 
+    assert.deepEqual(slider.noUiSlider.get(true), [50, 100], 'Unencoded values match');
+
     slider.noUiSlider.set([150, 600]);
 
     assert.deepEqual(slider.noUiSlider.get(), ['150', '600'], 'Slider correctly overstepped limits.');
+    assert.deepEqual(slider.noUiSlider.get(true), [150, 600], 'Unencoded values match.');
 
 });
 


### PR DESCRIPTION
This pr adds an api for retrieving the unencoded values which currently isn't possible.

It adds an optional argument to the `.get()` method which defaults to the current implementation and should have no effect on existing code. 

closes #1139 