### PR TITLE
additional aria config

### DIFF
--- a/src/nouislider.ts
+++ b/src/nouislider.ts
@@ -144,6 +144,7 @@ export interface Options extends UpdatableOptions {
     cssPrefix?: string;
     cssClasses?: CssClasses;
     ariaFormat?: PartialFormatter;
+    formatAllAriaAttributes: boolean;
     animationDuration?: number;
     handleAttributes?: HandleAttributes[];
 }
@@ -177,12 +178,12 @@ interface ParsedOptions {
     cssPrefix?: string | false;
     cssClasses: CssClasses;
     ariaFormat: PartialFormatter;
+    formatAllAriaAttributes: boolean;
     pips?: Pips;
     animationDuration: number;
     snap?: boolean;
     format: Formatter;
     handleAttributes?: HandleAttributes[];
-
     range: Range;
     singleStep: number;
     transformRule: "transform" | "msTransform" | "webkitTransform";
@@ -896,6 +897,15 @@ const INTERNAL_EVENT_NS = {
 
 //endregion
 
+function testformatAllAriaAttributes(parsed: ParsedOptions, entry: boolean): void {
+    if (typeof entry !== "boolean") {
+        throw new Error("noUiSlider: 'formatAllAriaAttributes' option must be a boolean.");
+    }
+
+    parsed.formatAllAriaAttributes = entry;
+}
+
+
 function testStep(parsed: ParsedOptions, entry: unknown): void {
     if (!isNumeric(entry)) {
         throw new Error("noUiSlider: 'step' is not numeric.");
@@ -1275,6 +1285,7 @@ function testOptions(options: Options): ParsedOptions {
         padding: { r: false, t: testPadding },
         behaviour: { r: true, t: testBehaviour },
         ariaFormat: { r: false, t: testAriaFormat },
+        formatAllAriaAttributes: {r: false, t: testformatAllAriaAttributes},
         format: { r: false, t: testFormat },
         tooltips: { r: false, t: testTooltips },
         keyboardSupport: { r: true, t: testKeyboardSupport },
@@ -1555,8 +1566,8 @@ function scope(target: TargetElement, options: ParsedOptions, originalOptions: O
                 const text = String(options.ariaFormat.to(unencoded[index]));
 
                 // Map to slider range values
-                min = <string>scope_Spectrum.fromStepping(min).toFixed(1);
-                max = <string>scope_Spectrum.fromStepping(max).toFixed(1);
+                min = <string>(options.formatAllAriaAttributes ? options.ariaFormat.to(unencoded[min]) : scope_Spectrum.fromStepping(min).toFixed(1));
+                max = <string>(options.formatAllAriaAttributes ? options.ariaFormat.to(unencoded[max]) : scope_Spectrum.fromStepping(max).toFixed(1));
                 now = <string>scope_Spectrum.fromStepping(now).toFixed(1);
 
                 handle.children[0].setAttribute("aria-valuemin", min);

--- a/tests/slider_aria.js
+++ b/tests/slider_aria.js
@@ -41,3 +41,48 @@ QUnit.test("Aria", function (assert) {
     assert.equal(handle1.getAttribute('aria-valuetext'), '150', 'Handle1 txt');
 
 });
+
+QUnit.test("Aria", function (assert) {
+
+    document.getElementById('qunit-fixture').innerHTML = '<div class="slider"></div>';
+
+    var slider = document.getElementById('qunit-fixture').querySelector('.slider');
+
+    noUiSlider.create(slider, {
+        start: [50, 150],
+        connect: true,
+        margin: 50,
+        ariaFormat: {
+            to: function (x) {
+                return Math.round(x).toString();
+            }, from: Number
+        },
+        formatAllAriaAttributes: true,
+        handleAttributes: [
+            { 'aria-label': 'lower' },
+            { 'aria-label': 'upper' },
+        ],
+        range: {
+            'min': 50,
+            'max': 1050
+        }
+    });
+
+    var handle0 = slider.querySelector('[data-handle="0"]');
+    var handle1 = slider.querySelector('[data-handle="1"]');
+
+    assert.equal(handle0.getAttribute('role'), 'slider');
+
+    assert.equal(handle0.getAttribute('aria-label'), 'lower');
+    assert.equal(handle0.getAttribute('aria-valuemin'), '50', 'Handle0 min');
+    assert.equal(handle0.getAttribute('aria-valuemax'), '100', 'Handle0 max');
+    assert.equal(handle0.getAttribute('aria-valuenow'), '50.0', 'Handle0 now');
+    assert.equal(handle0.getAttribute('aria-valuetext'), '50', 'Handle0 txt');
+
+    assert.equal(handle1.getAttribute('aria-label'), 'upper');
+    assert.equal(handle1.getAttribute('aria-valuemin'), '100', 'Handle1 min');
+    assert.equal(handle1.getAttribute('aria-valuemax'), '1050', 'Handle1 max');
+    assert.equal(handle1.getAttribute('aria-valuenow'), '150.0', 'Handle1 now');
+    assert.equal(handle1.getAttribute('aria-valuetext'), '150', 'Handle1 txt');
+
+});

--- a/tests/slider_aria.js
+++ b/tests/slider_aria.js
@@ -42,7 +42,7 @@ QUnit.test("Aria", function (assert) {
 
 });
 
-QUnit.test("Aria", function (assert) {
+QUnit.test("Aria all config", function (assert) {
 
     document.getElementById('qunit-fixture').innerHTML = '<div class="slider"></div>';
 


### PR DESCRIPTION
I have a scenario where I need to be able to format the aria min/max values to a more readable format because I am working a time based slider. 

The current aria config works great but I need it to be applicable to both additional fields and I am not able to pass in these aria config as attributes because they get overwritten when moving the slider.

Also there is not documentation it seems for running the tests.