### PR TITLE
Don't rebuild tooltips unnecessarily with updateOptions

### DIFF
--- a/src/nouislider.ts
+++ b/src/nouislider.ts
@@ -2928,12 +2928,14 @@ function scope(target: TargetElement, options: ParsedOptions, originalOptions: O
         options.limit = newOptions.limit;
         options.padding = newOptions.padding;
 
-        // Update pips, removes existing.
-        if (options.pips) {
+        if (optionsToUpdate.pips !== undefined) {
+          // Update pips, removes existing.
+          if (options.pips) {
             pips(options.pips);
-        } else {
+          } else {
             removePips();
-        }
+          }
+	}
 
         if (optionsToUpdate.tooltips !== undefined) {
             // Update tooltips, removes existing.

--- a/src/nouislider.ts
+++ b/src/nouislider.ts
@@ -2935,11 +2935,13 @@ function scope(target: TargetElement, options: ParsedOptions, originalOptions: O
             removePips();
         }
 
-        // Update tooltips, removes existing.
-        if (options.tooltips) {
-            tooltips();
-        } else {
-            removeTooltips();
+        if (optionsToUpdate.tooltips) {
+            // Update tooltips, removes existing.
+            if (options.tooltips) {
+                tooltips();
+            } else {
+                removeTooltips();
+            }
         }
 
         // Invalidate the current positioning so valueSet forces an update.

--- a/src/nouislider.ts
+++ b/src/nouislider.ts
@@ -2935,7 +2935,7 @@ function scope(target: TargetElement, options: ParsedOptions, originalOptions: O
             removePips();
         }
 
-        if (optionsToUpdate.tooltips) {
+        if (optionsToUpdate.tooltips !== undefined) {
             // Update tooltips, removes existing.
             if (options.tooltips) {
                 tooltips();


### PR DESCRIPTION

 - problem manifested when using example recipe 'Merging overlapping tooltips' and then subsequently doing `updateOptions({margin: 60})`
 - problem was that tooltips no longer exhibeted overlapping behaviour as they had been recreated from original config

ref: https://refreshless.com/nouislider/examples/#section-merging-tooltips