### PR TITLE
Improve type for custom range value

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "nouislider",
-      "version": "15.5.1",
+      "version": "15.6.0",
       "license": "MIT",
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^5.10",

--- a/src/nouislider.ts
+++ b/src/nouislider.ts
@@ -70,7 +70,7 @@ type SubRange = number | WrappedSubRange;
 interface Range {
     min: SubRange;
     max: SubRange;
-    [key: string]: SubRange;
+    [key: `${number}%`]: SubRange;
 }
 
 //region Pips


### PR DESCRIPTION
I've looked all over the docs and from what it seems when adding a custom range point, it must be in the format of a percentage, e.g. `"50%"`.

```ts
range: {
  min: [0, 1],
  "50%": [20, 5],
  max: 50
}
```

This PR improves the type for the custom keys to ensure they match the pattern of a percentage as opposed to allowing any string such as `"50 percent"`.

Please correct me if I've got this incorrect though, I just see no docs that say these custom values should be anything other than this.

---

**Side note**

When installing dependencies via `npm i`, it updated `package-lock.json` with the current version of this package, let me know if you want this reverting.