### PR TITLE
Corrects getTooltips and getOrigins return types to arrays

### DIFF
--- a/src/nouislider.ts
+++ b/src/nouislider.ts
@@ -216,8 +216,8 @@ export interface API {
     removePips: () => void;
     removeTooltips: () => void;
     getPositions: () => number[];
-    getTooltips: () => { [handleNumber: number]: HTMLElement | false };
-    getOrigins: () => { [handleNumber: number]: HTMLElement };
+    getTooltips: () => (HTMLElement | false)[] | null;
+    getOrigins: () => HTMLElement[];
     pips: (grid: Pips) => HTMLElement;
 }
 


### PR DESCRIPTION
Changes the types of `API.getTooltips` and `API.getOrigins` to arrays, as the typings that were previously there (using index signatures) didn't have array properties and methods like `.length` and `.forEach`.